### PR TITLE
Miscellaneous updates

### DIFF
--- a/Makefile.devkit
+++ b/Makefile.devkit
@@ -39,3 +39,7 @@ flash/%:
 		&& return 1 \
 		)
 	idf.py --project-dir $(patsubst flash/%,%,$@) --port rfc2217://host.docker.internal:4000?ign_set_control flash
+
+.PHONY: run/%
+run/%: $(BUILDS)
+	./$$(find $(patsubst run/%,%,$@)/build -name "*.elf" | head -n 1)

--- a/bin/get_apps
+++ b/bin/get_apps
@@ -8,4 +8,4 @@
 
 set -euo pipefail
 
-find . | grep 'main/idf_component.yml' | xargs -n 1 dirname | xargs -n 1 dirname
+find . | grep 'main/idf_component.yml' | grep -v managed_components | xargs -n 1 dirname | xargs -n 1 dirname


### PR DESCRIPTION
- Recursive `find` commands were causing examples and test apps in `managed_components` directories to be built. This commit excludes those directories.
- Add `run/<app>` directive for components.